### PR TITLE
Implicit structure create fix

### DIFF
--- a/src/insert.rs
+++ b/src/insert.rs
@@ -48,7 +48,7 @@ pub trait TomlValueInsertExt {
 impl TomlValueInsertExt for Value {
 
     fn insert_with_seperator(&mut self, query: &str, sep: char, value: Value) -> Result<Option<Value>> {
-        use resolver::mut_resolver::resolve;
+        use resolver::mut_creating_resolver::resolve;
 
         let mut tokens = try!(tokenize_with_seperator(query, sep));
         let last       = tokens.pop_last().unwrap();

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -28,11 +28,53 @@ pub trait TomlValueInsertExt {
     /// If a Value is inserted into an Array, the array indexes are shifted. Semantically this is
     /// the same as doing a `array.insert(4, _)` (see the standard library).
     ///
+    /// ## Known Bugs
+    ///
+    /// The current implementation does _not_ create intermediate Arrays as described above.
+    /// This is a known bug. So queries like "foo.bar.[0].baz" (or any query which has an array
+    /// element) will fail with an error rather than work.
+    ///
     /// # Return value
     ///
     /// If the insert operation worked correctly, `Ok(None)` is returned.
     /// If the insert operation replaced an existing value `Ok(Some(old_value))` is returned
     /// On failure, `Err(e)` is returned
+    ///
+    /// # Examples
+    ///
+    /// The following example shows a working `insert_with_seperator()` call on an empty toml
+    /// document. The Value is inserted as `"foo.bar = 1"` in the document.
+    ///
+    /// ```rust
+    /// extern crate toml;
+    /// extern crate toml_query;
+    ///
+    /// let mut toml : toml::Value = toml::from_str("").unwrap();
+    /// let query = "foo.bar";
+    /// let sep = '.';
+    /// let val = toml::Value::Integer(1);
+    ///
+    /// let res = toml_query::insert::TomlValueInsertExt::insert_with_seperator(&mut toml, query, sep, val);
+    /// assert!(res.is_ok());
+    /// let res = res.unwrap();
+    /// assert!(res.is_none());
+    /// ```
+    ///
+    /// The following example shows a failing `insert_with_seperator()` call on an empty toml
+    /// document. The Query does contain an array token, which does not yet work.
+    ///
+    /// ```rust,should_panic
+    /// extern crate toml;
+    /// extern crate toml_query;
+    ///
+    /// let mut toml : toml::Value = toml::from_str("").unwrap();
+    /// let query = "foo.[0]";
+    /// let sep = '.';
+    /// let val = toml::Value::Integer(1);
+    ///
+    /// let res = toml_query::insert::TomlValueInsertExt::insert_with_seperator(&mut toml, query, sep, val);
+    /// assert!(res.is_ok()); // panics
+    /// ```
     ///
     fn insert_with_seperator(&mut self, query: &str, sep: char, value: Value) -> Result<Option<Value>>;
 

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -299,5 +299,44 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_insert_with_seperator_into_table_with_nonexisting_keys() {
+        let mut toml : Value = toml_from_str(r#"
+        "#).unwrap();
+
+        let res = toml.insert_with_seperator(&String::from("table.a"), '.', Value::Integer(1));
+
+        assert!(res.is_ok());
+
+        let res = res.unwrap();
+        assert!(res.is_none());
+
+        assert!(is_match!(toml, Value::Table(_)));
+        match toml {
+            Value::Table(ref t) => {
+                assert!(!t.is_empty());
+
+                let table = t.get("table");
+                assert!(table.is_some());
+
+                let table = table.unwrap();
+                assert!(is_match!(table, &Value::Table(_)));
+                match table {
+                    &Value::Table(ref t) => {
+                        assert!(!t.is_empty());
+
+                        let a = t.get("a");
+                        assert!(a.is_some());
+
+                        let a = a.unwrap();
+                        assert!(is_match!(a, &Value::Integer(1)));
+                    },
+                    _ => panic!("What just happenend?"),
+                }
+            },
+            _ => panic!("What just happenend?"),
+        }
+    }
+
 }
 

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1,2 +1,3 @@
 pub mod mut_resolver;
+pub mod mut_creating_resolver;
 pub mod non_mut_resolver;

--- a/src/resolver/mut_creating_resolver.rs
+++ b/src/resolver/mut_creating_resolver.rs
@@ -1,0 +1,462 @@
+/// The query resolver that operates on the AST and the TOML object
+
+use std::collections::BTreeMap;
+
+use toml::Value;
+use tokenizer::Token;
+use error::*;
+
+pub fn resolve<'doc>(toml: &'doc mut Value, tokens: &Token) -> Result<&'doc mut Value> {
+    match toml {
+        &mut Value::Table(ref mut t) => {
+            match tokens {
+                &Token::Identifier { ref ident, .. } => {
+                    let mut sub_document = t
+                        .entry(ident.clone())
+                        .or_insert(Value::Table(BTreeMap::new()));
+
+                    match tokens.next() {
+                        Some(next) => resolve(sub_document, next),
+                        None => Ok(sub_document),
+                    }
+                },
+
+                &Token::Index { idx, .. } => {
+                    let kind = ErrorKind::NoIndexInTable(idx);
+                    Err(Error::from(kind))
+                },
+            }
+        },
+
+        &mut Value::Array(ref mut ary) => {
+            match tokens {
+                &Token::Index { idx, .. } => {
+                    match tokens.next() {
+                        Some(next) => resolve(ary.get_mut(idx).unwrap(), next),
+                        None       => Ok(ary.index_mut(idx)),
+                    }
+                },
+                &Token::Identifier { ref ident, .. } => {
+                    let kind = ErrorKind::NoIdentifierInArray(ident.clone());
+                    Err(Error::from(kind))
+                },
+            }
+        },
+
+        _ => match tokens {
+            &Token::Identifier { ref ident, .. } => {
+                Err(Error::from(ErrorKind::QueryingValueAsTable(ident.clone())))
+            },
+
+            &Token::Index { idx, .. } => {
+                Err(Error::from(ErrorKind::QueryingValueAsArray(idx)))
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use toml::from_str as toml_from_str;
+    use toml::Value;
+    use tokenizer::*;
+    use super::resolve;
+
+    macro_rules! do_resolve {
+        ( $toml:ident => $query:expr ) => {
+            resolve(&mut $toml, &tokenize_with_seperator(&String::from($query), '.').unwrap())
+        }
+    }
+
+    #[test]
+    fn test_resolve_empty_toml_simple_query() {
+        let mut toml = toml_from_str("").unwrap();
+        let result = do_resolve!(toml => "example");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert!(is_match!(result, &mut Value::Table(_)));
+        match result {
+            &mut Value::Table(ref tab) => assert!(tab.is_empty()),
+            _ => assert!(false, "Expected Table, got something else"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_present_bool() {
+        let mut toml = toml_from_str("example = true").unwrap();
+        let result = do_resolve!(toml => "example");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Boolean(true)));
+    }
+
+    #[test]
+    fn test_resolve_present_integer() {
+        let mut toml = toml_from_str("example = 1").unwrap();
+        let result = do_resolve!(toml => "example");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Integer(1)));
+    }
+
+    #[test]
+    fn test_resolve_present_float() {
+        let mut toml = toml_from_str("example = 1.0").unwrap();
+        let result = do_resolve!(toml => "example");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Float(1.0)));
+    }
+
+    #[test]
+    fn test_resolve_present_string() {
+        let mut toml = toml_from_str("example = 'string'").unwrap();
+        let result = do_resolve!(toml => "example");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::String(_)));
+        match result {
+            &mut Value::String(ref s) => assert_eq!("string", s),
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_present_array_bools() {
+        let mut toml = toml_from_str("example = [ true, false ]").unwrap();
+        let result = do_resolve!(toml => "example");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Array(_)));
+        match result {
+            &mut Value::Array(ref ary) => {
+                assert_eq!(ary[0], Value::Boolean(true));
+                assert_eq!(ary[1], Value::Boolean(false));
+            },
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_present_array_integers() {
+        let mut toml = toml_from_str("example = [ 1, 1337 ]").unwrap();
+        let result = do_resolve!(toml => "example");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Array(_)));
+        match result {
+            &mut Value::Array(ref ary) => {
+                assert_eq!(ary[0], Value::Integer(1));
+                assert_eq!(ary[1], Value::Integer(1337));
+            },
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_present_array_floats() {
+        let mut toml = toml_from_str("example = [ 1.0, 133.25 ]").unwrap();
+        let result = do_resolve!(toml => "example");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Array(_)));
+        match result {
+            &mut Value::Array(ref ary) => {
+                assert_eq!(ary[0], Value::Float(1.0));
+                assert_eq!(ary[1], Value::Float(133.25));
+            },
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_array_index_query_1() {
+        let mut toml = toml_from_str("example = [ 1 ]").unwrap();
+        let result = do_resolve!(toml => "example.[0]");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Integer(1)));
+    }
+
+    #[test]
+    fn test_resolve_array_index_query_2() {
+        let mut toml = toml_from_str("example = [ 1, 2, 3, 4, 5 ]").unwrap();
+        let result = do_resolve!(toml => "example.[4]");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Integer(5)));
+    }
+
+    #[test]
+    fn test_resolve_table_element_query() {
+        let mut toml = toml_from_str(r#"
+        [table]
+        value = 42
+        "#).unwrap();
+        let result = do_resolve!(toml => "table.value");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Integer(42)));
+    }
+
+    #[test]
+    fn test_resolve_table_with_many_elements_element_query() {
+        let mut toml = toml_from_str(r#"
+        [table]
+        value1 = 42
+        value2 = 43
+        value3 = 44
+        value4 = 45
+        value5 = 46
+        "#).unwrap();
+        let result = do_resolve!(toml => "table.value1");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Integer(42)));
+    }
+
+    #[test]
+    fn test_resolve_table_array_query() {
+        let mut toml = toml_from_str(r#"
+        [table]
+        value1 = [ 42.0, 50.0 ]
+        "#).unwrap();
+        let result = do_resolve!(toml => "table.value1");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Array(_)));
+        match result {
+            &mut Value::Array(ref ary) => {
+                assert_eq!(ary[0], Value::Float(42.0));
+                assert_eq!(ary[1], Value::Float(50.0));
+            },
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_table_array_element_query() {
+        let mut toml = toml_from_str(r#"
+        [table]
+        value1 = [ 42 ]
+        "#).unwrap();
+        let result = do_resolve!(toml => "table.value1.[0]");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Integer(42)));
+    }
+
+    #[test]
+    fn test_resolve_multi_table_query() {
+        let mut toml = toml_from_str(r#"
+        [table0]
+        value = [ 1 ]
+        [table1]
+        value = [ "Foo" ]
+        [table2]
+        value = [ 42.0 ]
+        [table3]
+        value = [ true ]
+        "#).unwrap();
+        let result = do_resolve!(toml => "table1.value.[0]");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::String(_)));
+        match result {
+            &mut Value::String(ref s) => assert_eq!("Foo", s),
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    static FRUIT_TABLE : &'static str = r#"
+    [[fruit.blah]]
+      name = "apple"
+
+      [fruit.blah.physical]
+        color = "red"
+        shape = "round"
+
+    [[fruit.blah]]
+      name = "banana"
+
+      [fruit.blah.physical]
+        color = "yellow"
+        shape = "bent"
+    "#;
+
+    #[test]
+    fn test_resolve_array_table_query_1() {
+        let mut toml = toml_from_str(FRUIT_TABLE).unwrap();
+        let result = do_resolve!(toml => "fruit.blah.[0].name");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::String(_)));
+        match result {
+            &mut Value::String(ref s) => assert_eq!("apple", s),
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_array_table_query_2() {
+        let mut toml = toml_from_str(FRUIT_TABLE).unwrap();
+        let result = do_resolve!(toml => "fruit.blah.[0].physical");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Table(_)));
+        match result {
+            &mut Value::Table(ref tab) => {
+                match tab.get("color") {
+                    Some(&Value::String(ref s)) => assert_eq!("red", s),
+                    _ => assert!(false),
+                }
+                match tab.get("shape") {
+                    Some(&Value::String(ref s)) => assert_eq!("round", s),
+                    _ => assert!(false),
+                }
+            },
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_query_on_result() {
+        let mut toml = toml_from_str(FRUIT_TABLE).unwrap();
+        let result = do_resolve!(toml => "fruit.blah.[1].physical");
+
+        assert!(result.is_ok());
+        let mut result = result.unwrap();
+
+        let tokens = tokenize_with_seperator(&String::from("color"), '.').unwrap();
+        let result = resolve(result, &tokens);
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::String(_)));
+        match result {
+            &mut Value::String(ref s) => assert_eq!("yellow", s),
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_query_empty_table() {
+        let mut toml = toml_from_str(r#"
+        [example]
+        "#).unwrap();
+        let result = do_resolve!(toml => "example");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(is_match!(result, &mut Value::Table(_)));
+        match result {
+            &mut Value::Table(ref t) => assert!(t.is_empty()),
+            _ => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_query_member_of_empty_table() {
+        let mut toml = toml_from_str("").unwrap();
+        let result = do_resolve!(toml => "example.foo");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert!(is_match!(result, &mut Value::Table(_)));
+        match result {
+            &mut Value::Table(ref t) => assert!(t.is_empty()),
+            _                        => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_query_index_in_table() {
+        let mut toml = toml_from_str("").unwrap();
+        let result = do_resolve!(toml => "example.[0]");
+
+        assert!(result.is_err());
+        let result = result.unwrap_err();
+
+        let errkind = result.kind();
+        assert!(is_match!(errkind, &ErrorKind::NoIndexInTable { .. }));
+    }
+
+    #[test]
+    fn test_resolve_query_identifier_in_array() {
+        let mut toml = toml_from_str("").unwrap();
+        let result = do_resolve!(toml => "example.foo.bar");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        match result {
+            &mut Value::Table(ref t) => assert!(t.is_empty()),
+            _                        => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_query_value_as_table() {
+        let mut toml = toml_from_str("").unwrap();
+        let result = do_resolve!(toml => "example.foo.bar");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        match result {
+            &mut Value::Table(ref t) => assert!(t.is_empty()),
+            _                        => panic!("What just happened?"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_query_value_as_array() {
+        let mut toml = toml_from_str("").unwrap();
+        let result = do_resolve!(toml => "example.foo.[0]");
+
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        match result {
+            &mut Value::Array(ref a) => assert!(a.is_empty()),
+            _                        => panic!("What just happened?"),
+        }
+    }
+
+}
+


### PR DESCRIPTION
This is for the 0.1.1 release, as we "forgot" the implicit create on `insert()`.

I guess this will even result in 0.2.0 as I guess the interface will change a bit as the `insert()` function has a bit changed semantically.

Does not work yet, unfortunately... this is a hard problem...

@TheNeikos if you want to break your head, feel free to try to solve this puzzle here!