### PR TITLE
Use &str as query type instead of &String

### DIFF
--- a/src/delete.rs
+++ b/src/delete.rs
@@ -34,12 +34,12 @@ pub trait TomlValueDeleteExt {
     ///
     /// On failure, `Err(e)` is returned
     ///
-    fn delete_with_seperator(&mut self, query: &String, sep: char) -> Result<Option<Value>>;
+    fn delete_with_seperator(&mut self, query: &str, sep: char) -> Result<Option<Value>>;
 
     /// Extension function for inserting a value from the current toml::Value document
     ///
     /// See documentation of `TomlValueinsertExt::insert_with_seperator`
-    fn delete(&mut self, query: &String) -> Result<Option<Value>> {
+    fn delete(&mut self, query: &str) -> Result<Option<Value>> {
         self.delete_with_seperator(query, '.')
     }
 
@@ -47,7 +47,7 @@ pub trait TomlValueDeleteExt {
 
 impl TomlValueDeleteExt for Value {
 
-    fn delete_with_seperator(&mut self, query: &String, sep: char) -> Result<Option<Value>> {
+    fn delete_with_seperator(&mut self, query: &str, sep: char) -> Result<Option<Value>> {
         use resolver::mut_resolver::resolve;
         use std::ops::Index;
 

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -34,12 +34,12 @@ pub trait TomlValueInsertExt {
     /// If the insert operation replaced an existing value `Ok(Some(old_value))` is returned
     /// On failure, `Err(e)` is returned
     ///
-    fn insert_with_seperator(&mut self, query: &String, sep: char, value: Value) -> Result<Option<Value>>;
+    fn insert_with_seperator(&mut self, query: &str, sep: char, value: Value) -> Result<Option<Value>>;
 
     /// Extension function for inserting a value from the current toml::Value document
     ///
     /// See documentation of `TomlValueinsertExt::insert_with_seperator`
-    fn insert(&mut self, query: &String, value: Value) -> Result<Option<Value>> {
+    fn insert(&mut self, query: &str, value: Value) -> Result<Option<Value>> {
         self.insert_with_seperator(query, '.', value)
     }
 
@@ -47,7 +47,7 @@ pub trait TomlValueInsertExt {
 
 impl TomlValueInsertExt for Value {
 
-    fn insert_with_seperator(&mut self, query: &String, sep: char, value: Value) -> Result<Option<Value>> {
+    fn insert_with_seperator(&mut self, query: &str, sep: char, value: Value) -> Result<Option<Value>> {
         use resolver::mut_resolver::resolve;
 
         let mut tokens = try!(tokenize_with_seperator(query, sep));

--- a/src/read.rs
+++ b/src/read.rs
@@ -9,19 +9,19 @@ pub trait TomlValueReadExt<'doc> {
 
     /// Extension function for reading a value from the current toml::Value document
     /// using a custom seperator
-    fn read_with_seperator(&'doc self, query: &String, sep: char) -> Result<&'doc Value>;
+    fn read_with_seperator(&'doc self, query: &str, sep: char) -> Result<&'doc Value>;
 
     /// Extension function for reading a value from the current toml::Value document mutably
     /// using a custom seperator
-    fn read_mut_with_seperator(&'doc mut self, query: &String, sep: char) -> Result<&'doc mut Value>;
+    fn read_mut_with_seperator(&'doc mut self, query: &str, sep: char) -> Result<&'doc mut Value>;
 
     /// Extension function for reading a value from the current toml::Value document
-    fn read(&'doc self, query: &String) -> Result<&'doc Value> {
+    fn read(&'doc self, query: &str) -> Result<&'doc Value> {
         self.read_with_seperator(query, '.')
     }
 
     /// Extension function for reading a value from the current toml::Value document mutably
-    fn read_mut(&'doc mut self, query: &String) -> Result<&'doc mut Value> {
+    fn read_mut(&'doc mut self, query: &str) -> Result<&'doc mut Value> {
         self.read_mut_with_seperator(query, '.')
     }
 
@@ -29,13 +29,13 @@ pub trait TomlValueReadExt<'doc> {
 
 impl<'doc> TomlValueReadExt<'doc> for Value {
 
-    fn read_with_seperator(&'doc self, query: &String, sep: char) -> Result<&'doc Value> {
+    fn read_with_seperator(&'doc self, query: &str, sep: char) -> Result<&'doc Value> {
         use resolver::non_mut_resolver::resolve;
 
         tokenize_with_seperator(query, sep).and_then(move |tokens| resolve(self, &tokens))
     }
 
-    fn read_mut_with_seperator(&'doc mut self, query: &String, sep: char) -> Result<&'doc mut Value> {
+    fn read_mut_with_seperator(&'doc mut self, query: &str, sep: char) -> Result<&'doc mut Value> {
         use resolver::mut_resolver::resolve;
 
         tokenize_with_seperator(query, sep).and_then(move |tokens| resolve(self, &tokens))

--- a/src/set.rs
+++ b/src/set.rs
@@ -26,12 +26,12 @@ pub trait TomlValueSetExt {
     ///     * If the query is `"a.b.[3]"` but the array at "`b"` has no index `3`: error
     ///     * etc.
     ///
-    fn set_with_seperator(&mut self, query: &String, sep: char, value: Value) -> Result<Option<Value>>;
+    fn set_with_seperator(&mut self, query: &str, sep: char, value: Value) -> Result<Option<Value>>;
 
     /// Extension function for setting a value from the current toml::Value document
     ///
     /// See documentation of `TomlValueSetExt::set_with_seperator`
-    fn set(&mut self, query: &String, value: Value) -> Result<Option<Value>> {
+    fn set(&mut self, query: &str, value: Value) -> Result<Option<Value>> {
         self.set_with_seperator(query, '.', value)
     }
 
@@ -39,7 +39,7 @@ pub trait TomlValueSetExt {
 
 impl TomlValueSetExt for Value {
 
-    fn set_with_seperator(&mut self, query: &String, sep: char, value: Value) -> Result<Option<Value>> {
+    fn set_with_seperator(&mut self, query: &str, sep: char, value: Value) -> Result<Option<Value>> {
         use resolver::mut_resolver::resolve;
 
         let mut tokens = try!(tokenize_with_seperator(query, sep));

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -95,7 +95,7 @@ impl Token {
 
 }
 
-pub fn tokenize_with_seperator(query: &String, seperator: char) -> Result<Token> {
+pub fn tokenize_with_seperator(query: &str, seperator: char) -> Result<Token> {
     use std::str::Split;
 
     /// Creates a Token object from a string


### PR DESCRIPTION
I honestly do not know why we used `&String` instead of `&str` - fix this!