### PR TITLE
Read optional

### DIFF
--- a/src/delete.rs
+++ b/src/delete.rs
@@ -535,7 +535,7 @@ mod test {
         array = [ 1 ]
         "#).unwrap();
 
-        let mut ary = toml.read_mut(&String::from("array")).unwrap();
+        let mut ary = toml.read_mut(&String::from("array")).unwrap().unwrap();
         let res     = ary.delete_with_seperator(&String::from("[0]"), '.');
 
         assert!(res.is_ok());
@@ -552,7 +552,7 @@ mod test {
         array = [ 1 ]
         "#).unwrap();
 
-        let mut ary = toml.read_mut(&String::from("array.[0]")).unwrap();
+        let mut ary = toml.read_mut(&String::from("array.[0]")).unwrap().unwrap();
         let res     = ary.delete_with_seperator(&String::from("nonexist"), '.');
 
         assert!(res.is_err());
@@ -569,7 +569,7 @@ mod test {
         array = 1
         "#).unwrap();
 
-        let mut ary = toml.read_mut(&String::from("array")).unwrap();
+        let mut ary = toml.read_mut(&String::from("array")).unwrap().unwrap();
         let res     = ary.delete_with_seperator(&String::from("[0]"), '.');
 
         assert!(res.is_err());
@@ -656,7 +656,7 @@ mod test {
         array = [ { t = 1 }, { t = 2 } ]
         "#).unwrap();
 
-        let mut ary = toml.read_mut(&String::from("array")).unwrap();
+        let mut ary = toml.read_mut(&String::from("array")).unwrap().unwrap();
         let res     = ary.delete_with_seperator(&String::from("[1]"), '.');
 
         assert!(res.is_err());

--- a/src/delete.rs
+++ b/src/delete.rs
@@ -149,7 +149,8 @@ impl TomlValueDeleteExt for Value {
                 }
             }
         } else {
-            let mut val = try!(resolve(self, &tokens));
+            let mut val = try!(resolve(self, &tokens, true))
+                .unwrap(); // safe because of resolve() guarantees
             let last_token = last_token.unwrap();
             match val {
                 &mut Value::Table(ref mut tab) => {

--- a/src/read.rs
+++ b/src/read.rs
@@ -32,13 +32,13 @@ impl<'doc> TomlValueReadExt<'doc> for Value {
     fn read_with_seperator(&'doc self, query: &str, sep: char) -> Result<Option<&'doc Value>> {
         use resolver::non_mut_resolver::resolve;
 
-        tokenize_with_seperator(query, sep).and_then(move |tokens| resolve(self, &tokens))
+        tokenize_with_seperator(query, sep).and_then(move |tokens| resolve(self, &tokens, false))
     }
 
     fn read_mut_with_seperator(&'doc mut self, query: &str, sep: char) -> Result<Option<&'doc mut Value>> {
         use resolver::mut_resolver::resolve;
 
-        tokenize_with_seperator(query, sep).and_then(move |tokens| resolve(self, &tokens))
+        tokenize_with_seperator(query, sep).and_then(move |tokens| resolve(self, &tokens, false))
     }
 
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -53,10 +53,11 @@ mod test {
         let toml : Value = toml_from_str("").unwrap();
 
         let val  = toml.read_with_seperator(&String::from("a"), '.');
-        assert!(val.is_err());
-        let err = val.unwrap_err();
 
-        assert!(is_match!(err.kind(), &ErrorKind::IdentifierNotFoundInDocument(_)));
+        assert!(val.is_ok());
+        let val = val.unwrap();
+
+        assert!(val.is_none());
     }
 
     #[test]
@@ -66,7 +67,11 @@ mod test {
         "#).unwrap();
 
         let val  = toml.read_with_seperator(&String::from("table"), '.');
+
         assert!(val.is_ok());
+        let val = val.unwrap();
+
+        assert!(val.is_some());
         let val = val.unwrap();
 
         assert!(is_match!(val, &Value::Table(_)));
@@ -84,7 +89,11 @@ mod test {
         "#).unwrap();
 
         let val  = toml.read_with_seperator(&String::from("table.a"), '.');
+
         assert!(val.is_ok());
+        let val = val.unwrap();
+
+        assert!(val.is_some());
         let val = val.unwrap();
 
         assert!(is_match!(val, &Value::Integer(1)));
@@ -97,10 +106,10 @@ mod test {
         "#).unwrap();
 
         let val  = toml.read_with_seperator(&String::from("table.a"), '.');
-        assert!(val.is_err());
-        let err = val.unwrap_err();
+        assert!(val.is_ok());
+        let val = val.unwrap();
 
-        assert!(is_match!(err.kind(), &ErrorKind::IdentifierNotFoundInDocument(_)));
+        assert!(val.is_none());
     }
 
     #[test]
@@ -127,10 +136,10 @@ mod test {
         let toml : Value = toml_from_str("").unwrap();
 
         let val  = toml.read(&String::from("a"));
-        assert!(val.is_err());
-        let err = val.unwrap_err();
+        assert!(val.is_ok());
+        let val = val.unwrap();
 
-        assert!(is_match!(err.kind(), &ErrorKind::IdentifierNotFoundInDocument(_)));
+        assert!(val.is_none());
     }
 
     #[test]
@@ -140,7 +149,11 @@ mod test {
         "#).unwrap();
 
         let val  = toml.read(&String::from("table"));
+
         assert!(val.is_ok());
+        let val = val.unwrap();
+
+        assert!(val.is_some());
         let val = val.unwrap();
 
         assert!(is_match!(val, &Value::Table(_)));
@@ -158,7 +171,11 @@ mod test {
         "#).unwrap();
 
         let val  = toml.read(&String::from("table.a"));
+
         assert!(val.is_ok());
+        let val = val.unwrap();
+
+        assert!(val.is_some());
         let val = val.unwrap();
 
         assert!(is_match!(val, &Value::Integer(1)));
@@ -171,10 +188,10 @@ mod test {
         "#).unwrap();
 
         let val  = toml.read(&String::from("table.a"));
-        assert!(val.is_err());
-        let err = val.unwrap_err();
+        assert!(val.is_ok());
+        let val = val.unwrap();
 
-        assert!(is_match!(err.kind(), &ErrorKind::IdentifierNotFoundInDocument(_)));
+        assert!(val.is_none());
     }
 
     #[test]

--- a/src/read.rs
+++ b/src/read.rs
@@ -9,19 +9,19 @@ pub trait TomlValueReadExt<'doc> {
 
     /// Extension function for reading a value from the current toml::Value document
     /// using a custom seperator
-    fn read_with_seperator(&'doc self, query: &str, sep: char) -> Result<&'doc Value>;
+    fn read_with_seperator(&'doc self, query: &str, sep: char) -> Result<Option<&'doc Value>>;
 
     /// Extension function for reading a value from the current toml::Value document mutably
     /// using a custom seperator
-    fn read_mut_with_seperator(&'doc mut self, query: &str, sep: char) -> Result<&'doc mut Value>;
+    fn read_mut_with_seperator(&'doc mut self, query: &str, sep: char) -> Result<Option<&'doc mut Value>>;
 
     /// Extension function for reading a value from the current toml::Value document
-    fn read(&'doc self, query: &str) -> Result<&'doc Value> {
+    fn read(&'doc self, query: &str) -> Result<Option<&'doc Value>> {
         self.read_with_seperator(query, '.')
     }
 
     /// Extension function for reading a value from the current toml::Value document mutably
-    fn read_mut(&'doc mut self, query: &str) -> Result<&'doc mut Value> {
+    fn read_mut(&'doc mut self, query: &str) -> Result<Option<&'doc mut Value>> {
         self.read_mut_with_seperator(query, '.')
     }
 
@@ -29,13 +29,13 @@ pub trait TomlValueReadExt<'doc> {
 
 impl<'doc> TomlValueReadExt<'doc> for Value {
 
-    fn read_with_seperator(&'doc self, query: &str, sep: char) -> Result<&'doc Value> {
+    fn read_with_seperator(&'doc self, query: &str, sep: char) -> Result<Option<&'doc Value>> {
         use resolver::non_mut_resolver::resolve;
 
         tokenize_with_seperator(query, sep).and_then(move |tokens| resolve(self, &tokens))
     }
 
-    fn read_mut_with_seperator(&'doc mut self, query: &str, sep: char) -> Result<&'doc mut Value> {
+    fn read_mut_with_seperator(&'doc mut self, query: &str, sep: char) -> Result<Option<&'doc mut Value>> {
         use resolver::mut_resolver::resolve;
 
         tokenize_with_seperator(query, sep).and_then(move |tokens| resolve(self, &tokens))

--- a/src/resolver/mut_resolver.rs
+++ b/src/resolver/mut_resolver.rs
@@ -64,7 +64,7 @@ mod test {
 
     macro_rules! do_resolve {
         ( $toml:ident => $query:expr ) => {
-            resolve(&mut $toml, &tokenize_with_seperator(&String::from($query), '.').unwrap())
+            resolve(&mut $toml, &tokenize_with_seperator(&String::from($query), '.').unwrap(), true)
         }
     }
 
@@ -88,7 +88,7 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
-        assert!(is_match!(result, &mut Value::Boolean(true)));
+        assert!(is_match!(result, Some(&mut Value::Boolean(true))));
     }
 
     #[test]
@@ -99,7 +99,7 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
-        assert!(is_match!(result, &mut Value::Integer(1)));
+        assert!(is_match!(result, Some(&mut Value::Integer(1))));
     }
 
     #[test]
@@ -108,6 +108,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::Float(1.0)));
@@ -119,6 +122,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::String(_)));
@@ -134,6 +140,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::Array(_)));
@@ -154,6 +163,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &mut Value::Array(_)));
         match result {
             &mut Value::Array(ref ary) => {
@@ -170,6 +182,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::Array(_)));
@@ -190,6 +205,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &mut Value::Integer(1)));
     }
 
@@ -199,6 +217,9 @@ mod test {
         let result = do_resolve!(toml => "example.[4]");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::Integer(5)));
@@ -213,6 +234,9 @@ mod test {
         let result = do_resolve!(toml => "table.value");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::Integer(42)));
@@ -233,6 +257,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &mut Value::Integer(42)));
     }
 
@@ -245,6 +272,9 @@ mod test {
         let result = do_resolve!(toml => "table.value1");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::Array(_)));
@@ -268,6 +298,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &mut Value::Integer(42)));
     }
 
@@ -286,6 +319,9 @@ mod test {
         let result = do_resolve!(toml => "table1.value.[0]");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::String(_)));
@@ -319,6 +355,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &mut Value::String(_)));
         match result {
             &mut Value::String(ref s) => assert_eq!("apple", s),
@@ -332,6 +371,9 @@ mod test {
         let result = do_resolve!(toml => "fruit.blah.[0].physical");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::Table(_)));
@@ -356,12 +398,18 @@ mod test {
         let result = do_resolve!(toml => "fruit.blah.[1].physical");
 
         assert!(result.is_ok());
-        let mut result = result.unwrap();
+        let result = result.unwrap();
+
+        assert!(result.is_some());
+        let result = result.unwrap();
 
         let tokens = tokenize_with_seperator(&String::from("color"), '.').unwrap();
-        let result = resolve(result, &tokens);
+        let result = resolve(result, &tokens, true);
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::String(_)));
@@ -379,6 +427,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &mut Value::Table(_)));

--- a/src/resolver/non_mut_resolver.rs
+++ b/src/resolver/non_mut_resolver.rs
@@ -64,7 +64,7 @@ mod test {
 
     macro_rules! do_resolve {
         ( $toml:ident => $query:expr ) => {
-            resolve(&$toml, &tokenize_with_seperator(&String::from($query), '.').unwrap())
+            resolve(&$toml, &tokenize_with_seperator(&String::from($query), '.').unwrap(), true)
         }
     }
 
@@ -88,6 +88,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &Value::Boolean(true)));
     }
 
@@ -97,6 +100,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::Integer(1)));
@@ -110,6 +116,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &Value::Float(1.0)));
     }
 
@@ -119,6 +128,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::String(_)));
@@ -134,6 +146,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::Array(_)));
@@ -154,6 +169,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &Value::Array(_)));
         match result {
             &Value::Array(ref ary) => {
@@ -170,6 +188,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::Array(_)));
@@ -190,6 +211,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &Value::Integer(1)));
     }
 
@@ -199,6 +223,9 @@ mod test {
         let result = do_resolve!(toml => "example.[4]");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::Integer(5)));
@@ -213,6 +240,9 @@ mod test {
         let result = do_resolve!(toml => "table.value");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::Integer(42)));
@@ -233,6 +263,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &Value::Integer(42)));
     }
 
@@ -245,6 +278,9 @@ mod test {
         let result = do_resolve!(toml => "table.value1");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::Array(_)));
@@ -268,6 +304,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &Value::Integer(42)));
     }
 
@@ -286,6 +325,9 @@ mod test {
         let result = do_resolve!(toml => "table1.value.[0]");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::String(_)));
@@ -319,6 +361,9 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         assert!(is_match!(result, &Value::String(_)));
         match result {
             &Value::String(ref s) => assert_eq!("apple", s),
@@ -332,6 +377,9 @@ mod test {
         let result = do_resolve!(toml => "fruit.blah.[0].physical");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::Table(_)));
@@ -358,10 +406,16 @@ mod test {
         assert!(result.is_ok());
         let result = result.unwrap();
 
+        assert!(result.is_some());
+        let result = result.unwrap();
+
         let tokens = tokenize_with_seperator(&String::from("color"), '.').unwrap();
-        let result = resolve(result, &tokens);
+        let result = resolve(result, &tokens, true);
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::String(_)));
@@ -379,6 +433,9 @@ mod test {
         let result = do_resolve!(toml => "example");
 
         assert!(result.is_ok());
+        let result = result.unwrap();
+
+        assert!(result.is_some());
         let result = result.unwrap();
 
         assert!(is_match!(result, &Value::Table(_)));

--- a/src/resolver/non_mut_resolver.rs
+++ b/src/resolver/non_mut_resolver.rs
@@ -6,15 +6,26 @@ use toml::Value;
 use tokenizer::Token;
 use error::*;
 
-pub fn resolve<'doc>(toml: &'doc Value, tokens: &Token) -> Result<Option<&'doc Value>> {
+/// Resolves the path in the passed document recursively
+///
+/// # Guarantees
+///
+/// If error_if_not_found is set to true, this function does not return Ok(None) in any case.
+///
+pub fn resolve<'doc>(toml: &'doc Value, tokens: &Token, error_if_not_found: bool) -> Result<Option<&'doc Value>> {
     match toml {
         &Value::Table(ref t) => {
             match tokens {
                 &Token::Identifier { ref ident, .. } => {
                     match t.get(ident) {
-                        None => Ok(None),
+                        None => if error_if_not_found {
+                            let err = ErrorKind::IdentifierNotFoundInDocument(ident.to_owned());
+                            return Err(Error::from(err))
+                        } else {
+                            Ok(None)
+                        },
                         Some(sub_document) => match tokens.next() {
-                            Some(next) => resolve(sub_document, next),
+                            Some(next) => resolve(sub_document, next, error_if_not_found),
                             None       => Ok(Some(sub_document)),
                         },
                     }
@@ -31,7 +42,7 @@ pub fn resolve<'doc>(toml: &'doc Value, tokens: &Token) -> Result<Option<&'doc V
             match tokens {
                 &Token::Index { idx, .. } => {
                     match tokens.next() {
-                        Some(next) => resolve(ary.get(idx).unwrap(), next),
+                        Some(next) => resolve(ary.get(idx).unwrap(), next, error_if_not_found),
                         None       => Ok(Some(ary.index(idx))),
                     }
                 },

--- a/src/set.rs
+++ b/src/set.rs
@@ -45,7 +45,8 @@ impl TomlValueSetExt for Value {
         let mut tokens = try!(tokenize_with_seperator(query, sep));
         let last = tokens.pop_last();
 
-        let mut val = try!(resolve(self, &tokens));
+        let mut val = try!(resolve(self, &tokens, true))
+            .unwrap(); // safe because of resolve() guarantees
         let last = last.unwrap_or_else(|| Box::new(tokens));
 
         match *last {

--- a/src/value.rs
+++ b/src/value.rs
@@ -29,25 +29,25 @@ pub trait TomlValueExt<'doc> :
 
     /// See documentation of `TomlValueReadExt`
     #[inline]
-    fn read_with_seperator(&'doc self, query: &String, sep: char) -> Result<&'doc Value> {
+    fn read_with_seperator(&'doc self, query: &String, sep: char) -> Result<Option<&'doc Value>> {
         TomlValueReadExt::read_with_seperator(self, query, sep)
     }
 
     /// See documentation of `TomlValueReadExt`
     #[inline]
-    fn read_mut_with_seperator(&'doc mut self, query: &String, sep: char) -> Result<&'doc mut Value> {
+    fn read_mut_with_seperator(&'doc mut self, query: &String, sep: char) -> Result<Option<&'doc mut Value>> {
         TomlValueReadExt::read_mut_with_seperator(self, query, sep)
     }
 
     /// See documentation of `TomlValueReadExt`
     #[inline]
-    fn read(&'doc self, query: &String) -> Result<&'doc Value> {
+    fn read(&'doc self, query: &String) -> Result<Option<&'doc Value>> {
         TomlValueReadExt::read_with_seperator(self, query, '.')
     }
 
     /// See documentation of `TomlValueReadExt`
     #[inline]
-    fn read_mut(&'doc mut self, query: &String) -> Result<&'doc mut Value> {
+    fn read_mut(&'doc mut self, query: &String) -> Result<Option<&'doc mut Value>> {
         TomlValueReadExt::read_mut_with_seperator(self, query, '.')
     }
 


### PR DESCRIPTION
This changes the return type for the read functionality to `Result<Option<_>>`, which is _way_ more convenient IMO.

This will be released as soon as the tests pass (and the version is bumped, but I will do that in another branch).