### PR TITLE
Add trait requirements: TomlValueReadTypeExt : TomlValueReadExt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ that version.
 
 # Next
 
+* `TomlValueReadTypeExt` requires now `TomlValueReadExt`.
+
 # 0.5.0
 
 * Minimum required rust compiler version is now 1.20.0

--- a/src/read.rs
+++ b/src/read.rs
@@ -43,7 +43,7 @@ impl<'doc> TomlValueReadExt<'doc> for Value {
 
 }
 
-pub trait TomlValueReadTypeExt<'doc> {
+pub trait TomlValueReadTypeExt<'doc> : TomlValueReadExt<'doc> {
     fn read_string(&'doc self, query: &str) -> Result<String>;
     fn read_int(&'doc self, query: &str) -> Result<i64>;
     fn read_float(&'doc self, query: &str) -> Result<f64>;


### PR DESCRIPTION
Add missing trait requirement.

This is much more sane.