### PR TITLE
Added an automatic de/serialization feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository    = "https://github.com/matthiasbeyer/toml-query"
 [features]
 default = []
 logging = [ "log" ]
+typed = ["serde"]
 
 [dependencies]
 toml = "0.4"
@@ -29,3 +30,6 @@ quickcheck = "0.6"
 version = "0.4"
 optional = true
 
+[dependencies.serde]
+version = "1.0"
+optional = true

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,11 @@ error_chain! {
         Error, ErrorKind, ResultExt, Result;
     }
 
+    foreign_links {
+        TomlSerialize(::toml::ser::Error) #[cfg(feature = "typed")];
+        TomlDeserialize(::toml::de::Error) #[cfg(feature = "typed")];
+    }
+
     errors {
 
         // Errors for tokenizer
@@ -92,4 +97,5 @@ error_chain! {
         }
 
     }
+
 }

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -1,5 +1,7 @@
 /// The Toml Insert extensions
 
+#[cfg(feature = "typed")]
+use serde::Serialize;
 use toml::Value;
 
 use tokenizer::Token;
@@ -83,6 +85,13 @@ pub trait TomlValueInsertExt {
     /// See documentation of `TomlValueinsertExt::insert_with_seperator`
     fn insert(&mut self, query: &str, value: Value) -> Result<Option<Value>> {
         self.insert_with_seperator(query, '.', value)
+    }
+
+    /// A convenience method for inserting any arbitrary serializable value.
+    #[cfg(feature = "typed")]
+    fn insert_serialized<S: Serialize>(&mut self, query: &str, value: S) -> Result<Option<Value>> {
+        let value = Value::try_from(value)?;
+        self.insert(query, value)
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ extern crate toml;
 #[cfg(feature = "log")]
 #[macro_use] extern crate log;
 
+#[cfg(feature = "typed")]
+extern crate serde;
+
 #[cfg(test)]
 #[macro_use] extern crate quickcheck;
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,5 +1,7 @@
 /// The Toml Set extensions
 
+#[cfg(feature = "typed")]
+use serde::Serialize;
 use toml::Value;
 
 use tokenizer::tokenize_with_seperator;
@@ -33,6 +35,13 @@ pub trait TomlValueSetExt {
     /// See documentation of `TomlValueSetExt::set_with_seperator`
     fn set(&mut self, query: &str, value: Value) -> Result<Option<Value>> {
         self.set_with_seperator(query, '.', value)
+    }
+
+    /// A convenience method for setting any arbitrary serializable value.
+    #[cfg(feature = "typed")]
+    fn set_serialized<S: Serialize>(&mut self, query: &str, value: S) -> Result<Option<Value>> {
+        let value = Value::try_from(value)?;
+        self.set(query, value)
     }
 
 }


### PR DESCRIPTION
This is what I had in mind when I commented on https://github.com/matthiasbeyer/toml-query/issues/23#issuecomment-357459609. 

Basically, the `*_serialized()` methods take advantage of the fact that a `toml::Value` has generic `try_into()` and `try_from()` methods. This lets you convert between a `Value` and anything which is serializable/deserializable with minimal friction. The methods provided by this `typed` feature flag (feel free to give it a better name) just acts as a shim between the current methods and `Value`'s `try_into()`/`try_from()`. I did pretty much the same thing [for mdbook].

This PR still needs more documentation and testing, but it shows off the general idea.

[for mdbook]: https://github.com/rust-lang-nursery/mdBook/blob/a1b6ccc29a5d4658bd03bf469f484d451716a747/src/config.rs#L123-L136