### PR TITLE
Prepare 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ that version.
 
 # Next
 
+# 0.7.0
+
+* API CHANGE: The `read`, `set`, `delete` and `insert` function took a
+  `&String` before for the value path. This changed, they now want a `&str`.
+  Existing Code _should_ work, as `String` derefs to `&str`.
+* Dependencies "error-chain" and "regex" were updated (thanks Bruce Mitchener)
+* Automatic de/serialization was added (See the new
+  {read,insert,delete,set}_serialize functions)
+
 # 0.6.0
 
 * `TomlValueReadTypeExt` requires now `TomlValueReadExt`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toml-query"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Matthias Beyer <mail@beyermatthias.de>"]
 
 description = "Library to work with toml::Value objects more conveniently"


### PR DESCRIPTION
As I learned today, `mdbook` depends on my crate.

As `mdbook` wants to update its dependencies, but we depend on old versions of regex and error-chain, here comes a release with these updated (and also a new feature and a API change).

@waywardmonkeys Please note the API change documented in the changelog file. Existing code _should_ not break, as `String` derefs to `&str`, but you'll never know, right?