### PR TITLE
doc: update repository link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 keywords = ["toml", "extension"]
 license = "MPL-2.0"
 readme = "./README.md"
-repository = "https://git.beyermatthi.as/toml-query"
+repository = "https://github.com/matthiasbeyer/toml-query"
 description = "Library to work with toml::Value objects more conveniently"
 
 [features]


### PR DESCRIPTION
Fixes 404 error when using the Repository links on [crates.io](https://crates.io/crates/toml-query) and [docs.rs](https://docs.rs/toml-query/)